### PR TITLE
Deal with an empty event filter string

### DIFF
--- a/twilio/internal/services/taskrouter/resource_taskrouter_workspace.go
+++ b/twilio/internal/services/taskrouter/resource_taskrouter_workspace.go
@@ -161,7 +161,7 @@ func resourceTaskRouterWorkspaceRead(ctx context.Context, d *schema.ResourceData
 	d.Set("friendly_name", getResponse.FriendlyName)
 	d.Set("event_callback_url", getResponse.EventCallbackURL)
 
-	if getResponse.EventsFilter != nil {
+	if getResponse.EventsFilter != nil && *getResponse.EventsFilter != "" {
 		d.Set("event_filters", strings.Split(*getResponse.EventsFilter, workspaceEventsSeperator))
 	}
 


### PR DESCRIPTION
If you set an event filter and then blank it later, the API can return an empty event filter string, which is equivalent to no event filter.