### PR TITLE
fix(messaging): Bump default validity period from 14400 to 36000

### DIFF
--- a/docs/resources/messaging_service.md
+++ b/docs/resources/messaging_service.md
@@ -38,7 +38,7 @@ The following arguments are supported:
 - `status_callback_url` - (Optional) The URL which will be called when a message delivery status is changed
 - `sticky_sender` - (Optional) Whether to ensure the end-user receives messages from the same phone number. The default value is `true`
 - `use_inbound_webhook_on_number` - (Optional) Whether to use the webhook that is configured on the phone number. The default value is `false`
-- `validity_period` - (Optional) How long (in seconds) messages sent from the messaging service are valid for. The value must be between `1` and `14400` (inclusive). The default value is `14400`
+- `validity_period` - (Optional) How long (in seconds) messages sent from the messaging service are valid for. The value must be between `1` and `36000` (inclusive). The default value is `36000`
 
 ## Attributes Reference
 

--- a/twilio/internal/services/messaging/resource_messaging_service.go
+++ b/twilio/internal/services/messaging/resource_messaging_service.go
@@ -125,8 +125,8 @@ func resourceMessagingService() *schema.Resource {
 			"validity_period": {
 				Type:         schema.TypeInt,
 				Optional:     true,
-				Default:      14400,
-				ValidateFunc: validation.IntBetween(1, 14400),
+				Default:      36000,
+				ValidateFunc: validation.IntBetween(1, 36000),
 			},
 			"date_created": {
 				Type:     schema.TypeString,

--- a/twilio/internal/services/messaging/tests/data_source_messaging_service_test.go
+++ b/twilio/internal/services/messaging/tests/data_source_messaging_service_test.go
@@ -37,7 +37,7 @@ func TestAccDataSourceTwilioMessagingService_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(stateDataSourceName, "status_callback_url", ""),
 					resource.TestCheckResourceAttr(stateDataSourceName, "sticky_sender", "true"),
 					resource.TestCheckResourceAttr(stateDataSourceName, "use_inbound_webhook_on_number", "false"),
-					resource.TestCheckResourceAttr(stateDataSourceName, "validity_period", "14400"),
+					resource.TestCheckResourceAttr(stateDataSourceName, "validity_period", "36000"),
 					resource.TestCheckResourceAttrSet(stateDataSourceName, "sid"),
 					resource.TestCheckResourceAttrSet(stateDataSourceName, "date_created"),
 					resource.TestCheckResourceAttrSet(stateDataSourceName, "date_updated"),

--- a/twilio/internal/services/messaging/tests/resource_messaging_service_test.go
+++ b/twilio/internal/services/messaging/tests/resource_messaging_service_test.go
@@ -42,7 +42,7 @@ func TestAccTwilioMessagingService_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(stateResourceName, "status_callback_url", ""),
 					resource.TestCheckResourceAttr(stateResourceName, "sticky_sender", "true"),
 					resource.TestCheckResourceAttr(stateResourceName, "use_inbound_webhook_on_number", "false"),
-					resource.TestCheckResourceAttr(stateResourceName, "validity_period", "14400"),
+					resource.TestCheckResourceAttr(stateResourceName, "validity_period", "36000"),
 					resource.TestCheckResourceAttrSet(stateResourceName, "sid"),
 					resource.TestCheckResourceAttrSet(stateResourceName, "date_created"),
 					resource.TestCheckResourceAttrSet(stateResourceName, "date_updated"),
@@ -88,7 +88,7 @@ func TestAccTwilioMessagingService_update(t *testing.T) {
 					resource.TestCheckResourceAttr(stateResourceName, "status_callback_url", ""),
 					resource.TestCheckResourceAttr(stateResourceName, "sticky_sender", "true"),
 					resource.TestCheckResourceAttr(stateResourceName, "use_inbound_webhook_on_number", "false"),
-					resource.TestCheckResourceAttr(stateResourceName, "validity_period", "14400"),
+					resource.TestCheckResourceAttr(stateResourceName, "validity_period", "36000"),
 					resource.TestCheckResourceAttrSet(stateResourceName, "sid"),
 					resource.TestCheckResourceAttrSet(stateResourceName, "date_created"),
 					resource.TestCheckResourceAttrSet(stateResourceName, "date_updated"),
@@ -113,7 +113,7 @@ func TestAccTwilioMessagingService_update(t *testing.T) {
 					resource.TestCheckResourceAttr(stateResourceName, "status_callback_url", ""),
 					resource.TestCheckResourceAttr(stateResourceName, "sticky_sender", "true"),
 					resource.TestCheckResourceAttr(stateResourceName, "use_inbound_webhook_on_number", "false"),
-					resource.TestCheckResourceAttr(stateResourceName, "validity_period", "14400"),
+					resource.TestCheckResourceAttr(stateResourceName, "validity_period", "36000"),
 					resource.TestCheckResourceAttrSet(stateResourceName, "sid"),
 					resource.TestCheckResourceAttrSet(stateResourceName, "date_created"),
 					resource.TestCheckResourceAttrSet(stateResourceName, "date_updated"),
@@ -317,7 +317,7 @@ func TestAccTwilioMessagingService_validityPeriod(t *testing.T) {
 	stateResourceName := fmt.Sprintf("%s.service", serviceResourceName)
 
 	friendlyName := acctest.RandString(10)
-	validityPeriod := 14400
+	validityPeriod := 36000
 	newValidityPeriod := 1
 
 	resource.ParallelTest(t, resource.TestCase{
@@ -328,7 +328,7 @@ func TestAccTwilioMessagingService_validityPeriod(t *testing.T) {
 				Config: testAccTwilioMessagingService_validityPeriod(friendlyName, validityPeriod),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTwilioMessagingServiceExists(stateResourceName),
-					resource.TestCheckResourceAttr(stateResourceName, "validity_period", "14400"),
+					resource.TestCheckResourceAttr(stateResourceName, "validity_period", "36000"),
 				),
 			},
 			{
@@ -342,7 +342,7 @@ func TestAccTwilioMessagingService_validityPeriod(t *testing.T) {
 				Config: testAccTwilioMessagingService_basic(friendlyName),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckTwilioMessagingServiceExists(stateResourceName),
-					resource.TestCheckResourceAttr(stateResourceName, "validity_period", "14400"),
+					resource.TestCheckResourceAttr(stateResourceName, "validity_period", "36000"),
 				),
 			},
 		},
@@ -359,7 +359,7 @@ func TestAccTwilioMessagingService_invalidValidityPeriodOf0(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccTwilioMessagingService_validityPeriod(friendlyName, validityPeriod),
-				ExpectError: regexp.MustCompile(`(?s)expected validity_period to be in the range \(1 - 14400\), got 0`),
+				ExpectError: regexp.MustCompile(`(?s)expected validity_period to be in the range \(1 - 36000\), got 0`),
 			},
 		},
 	})
@@ -375,7 +375,7 @@ func TestAccTwilioMessagingService_invalidValidityPeriodOf14401(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      testAccTwilioMessagingService_validityPeriod(friendlyName, validityPeriod),
-				ExpectError: regexp.MustCompile(`(?s)expected validity_period to be in the range \(1 - 14400\), got 14401`),
+				ExpectError: regexp.MustCompile(`(?s)expected validity_period to be in the range \(1 - 36000\), got 14401`),
 			},
 		},
 	})


### PR DESCRIPTION
https://www.twilio.com/en-us/changelog/extension-of-configurable-queue-ttl-validity-period#:~:text=Starting%20May%2012%2C%202025%2C%20Twilio,from%204%20to%2010%20hours.